### PR TITLE
Update scsi.go

### DIFF
--- a/pkg/scsi/scsi.go
+++ b/pkg/scsi/scsi.go
@@ -44,6 +44,7 @@ const (
 
 func NewSCSI(chroot string) *scsi {
 	scsi := &scsi{
+		chroot:	chroot,
 		fileReader: &wrp.IOUTILWrapper{},
 		filePath:   &wrp.FilepathWrapper{},
 		os:         &wrp.OSWrapper{},


### PR DESCRIPTION
To fix the problem that /lib/udev/scsi_id not found in csi-powerstore node pod because s.chroot is nil.