### PR TITLE
Updates scsi rescan to use the LUN number in rescan command

### DIFF
--- a/fc.go
+++ b/fc.go
@@ -520,7 +520,7 @@ func (fc *FCConnector) findHCTLsForFCHBA(
 	if needFullRescan {
 		// at least one target port not found, do full scsi rescan
 		hctlsToRescan = []scsi.HCTL{{
-			Host: hostDev, Lun: "-",
+			Host: hostDev, Lun: lun,
 			Channel: "-", Target: "-",
 		}}
 	} else {


### PR DESCRIPTION
# Description
This PR:
- This updates the rescan logic in **findHCTLsForFCHBA** function to use LUN number instead of '-', which scans for all the luns on a host.
- The LUN number is primarily part of NodeStageRequest.
- This saves us the issue of having a ghost/invalid sd* disk post NodeUnstage and there is a rescan for new devices at the same time.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1379|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit test
- [x] Cluster test
