### PR TITLE
Fix detection and matching of wwn to nguid.

### DIFF
--- a/nvme_test.go
+++ b/nvme_test.go
@@ -17,6 +17,7 @@ package gobrick
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -187,6 +188,33 @@ func TestNVME_Connector_ConnectVolume(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ConnectVolume() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNVME_wwnMatches(t *testing.T) {
+	tests := []struct {
+		nguid string
+		wwn   string
+		want  bool
+	}{
+		{nguid: "0f8da909812540628ccf09680039914f", wwn: "naa.68ccf098000f8da9098125406239914f", want: true},
+		{nguid: "0f8da909812540628ccf09680039914f", wwn: "NAA.68ccf098000f8da9098125406239914f", want: true},
+		{nguid: "0f8da909812540628ccf09680039914f", wwn: "68ccf098000f8da9098125406239914f", want: true},
+		{nguid: "0f8da909812540628ccf09680039914f", wwn: "68CCF098000F8DA9098125406239914F", want: true},
+		{nguid: "0f8da909812540628ccf09680039914f", wwn: "60000978000f8da9098125406239914f", want: false},
+		{nguid: "12635330303134340000976000012000", wwn: "60000970000120001263533030313434", want: true},
+		{nguid: "12635330303134340000976000012000", wwn: "68ccf070000120001263533030313434", want: false},
+		{nguid: "12635330303134340000976000012000", wwn: "8ccf070000120001263533030313434", want: false},
+		{nguid: "12635330303134340000976000012000", wwn: "68CCF070000120001263533030313434", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("(%s,%s) should be %v", tt.nguid, tt.wwn, tt.want), func(t *testing.T) {
+			c := &NVMeConnector{}
+			if c.wwnMatches(tt.nguid, tt.wwn) != tt.want {
+				t.Errorf("wwnMatches(%v, %v) = %v, want %v", tt.nguid, tt.wwn, !tt.want, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description
Fix regression introduced when matching device wwn with nguid. The fix will make the proper checks based on platform. Added unit tests for this method.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [1469](https://github.com/dell/csm/issues/1469) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I was able to reproduce the problem in the lab. Saw the same errors as reported. With the fix the failure is gone and the new log traces look like the following;

START: NVMeConnector.discoverDevice
{"level":"debug","msg":"DevicePathsAndNamespaces [{DevicePath:/dev/nvme0n1 Namespace:40074}] retryCount 0","time":"2024-09-19T03:50:49.015887629Z"}
{"level":"debug","msg":"nguid eafbf604e377aa068ccf096800495ec4, wwn 68ccf09800eafbf604e377aa06495ec4, newnamespace 40074, namespace 40074","time":"2024-09-19T03:50:49.038451238Z"}
**{"level":"info","msg":"PowerStore: bf604e377aa0 495ec eafbf604e377aa068ccf096800495ec4 true","time":"2024-09-19T03:50:49.038506058Z"}**
END: NVMeConnector.discoverDevice
{