### PR TITLE
Bugfix 1447 clean wwids file

### DIFF
--- a/fc.go
+++ b/fc.go
@@ -223,7 +223,7 @@ func (fc *FCConnector) cleanConnection(ctx context.Context, force bool, info FCV
 		}
 	}
 	logger.Info(ctx, "devices found: %s", devices)
-	return fc.baseConnector.cleanDevices(ctx, force, devices)
+	return fc.baseConnector.cleanDevices(ctx, force, devices, "")
 }
 
 func (fc *FCConnector) validateFCVolumeInfo(ctx context.Context, info FCVolumeInfo) error {

--- a/internal/multipath/interface.go
+++ b/internal/multipath/interface.go
@@ -27,6 +27,7 @@ type Multipath interface {
 	AddPath(ctx context.Context, path string) error
 	DelPath(ctx context.Context, path string) error
 	FlushDevice(ctx context.Context, deviceMapName string) error
+	RemoveDeviceFromWWIDSFile(ctx context.Context, wwid string) error
 	IsDaemonRunning(ctx context.Context) bool
 	GetDMWWID(ctx context.Context, deviceMapName string) (string, error)
 }

--- a/internal/multipath/multipath_mock.go
+++ b/internal/multipath/multipath_mock.go
@@ -133,14 +133,14 @@ func (mr *MockMultipathMockRecorder) GetDMWWID(ctx, deviceMapName interface{}) *
 
 // RemoveDeviceFromWWIDSFile mocks base method.
 func (m *MockMultipath) RemoveDeviceFromWWIDSFile(ctx context.Context, wwid string) error {
-        m.ctrl.T.Helper()
-        ret := m.ctrl.Call(m, "RemoveDeviceFromWWIDSFile", ctx, wwid)
-        ret0, _ := ret[0].(error)
-        return ret0
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveDeviceFromWWIDSFile", ctx, wwid)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // RemoveDeviceFromWWIDSFile indicates an expected call of RemoveDeviceFromWWIDSFile.
 func (mr *MockMultipathMockRecorder) RemoveDeviceFromWWIDSFile(ctx, wwid interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDeviceFromWWIDSFile", reflect.TypeOf((*MockMultipath)(nil).RemoveDeviceFromWWIDSFile), ctx, wwid)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDeviceFromWWIDSFile", reflect.TypeOf((*MockMultipath)(nil).RemoveDeviceFromWWIDSFile), ctx, wwid)
 }

--- a/internal/multipath/multipath_mock.go
+++ b/internal/multipath/multipath_mock.go
@@ -130,3 +130,17 @@ func (mr *MockMultipathMockRecorder) GetDMWWID(ctx, deviceMapName interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDMWWID", reflect.TypeOf((*MockMultipath)(nil).GetDMWWID), ctx, deviceMapName)
 }
+
+// RemoveDeviceFromWWIDSFile mocks base method.
+func (m *MockMultipath) RemoveDeviceFromWWIDSFile(ctx context.Context, wwid string) error {
+        m.ctrl.T.Helper()
+        ret := m.ctrl.Call(m, "RemoveDeviceFromWWIDSFile", ctx, wwid)
+        ret0, _ := ret[0].(error)
+        return ret0
+}
+
+// RemoveDeviceFromWWIDSFile indicates an expected call of RemoveDeviceFromWWIDSFile.
+func (mr *MockMultipathMockRecorder) RemoveDeviceFromWWIDSFile(ctx, wwid interface{}) *gomock.Call {
+        mr.mock.ctrl.T.Helper()
+        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDeviceFromWWIDSFile", reflect.TypeOf((*MockMultipath)(nil).RemoveDeviceFromWWIDSFile), ctx, wwid)
+}

--- a/iscsi.go
+++ b/iscsi.go
@@ -304,7 +304,7 @@ func (c *ISCSIConnector) cleanConnection(ctx context.Context, force bool, info I
 	if len(devices) == 0 {
 		return nil
 	}
-	return c.baseConnector.cleanDevices(ctx, force, devices)
+	return c.baseConnector.cleanDevices(ctx, force, devices, "")
 }
 
 func (c *ISCSIConnector) connectSingleDevice(

--- a/nvme.go
+++ b/nvme.go
@@ -298,7 +298,7 @@ func (c *NVMeConnector) cleanConnection(ctx context.Context, force bool, info NV
 	if len(devices) == 0 {
 		return nil
 	}
-	return c.baseConnector.cleanNVMeDevices(ctx, force, devices)
+	return c.baseConnector.cleanNVMeDevices(ctx, force, devices, wwn)
 }
 
 func (c *NVMeConnector) connectSingleDevice(ctx context.Context, info NVMeVolumeInfo, useFC bool) (Device, error) {

--- a/pkg/multipath/multipath.go
+++ b/pkg/multipath/multipath.go
@@ -87,6 +87,12 @@ func (mp *Multipath) FlushDevice(ctx context.Context, deviceMapName string) erro
 	return mp.flushDevice(ctx, deviceMapName)
 }
 
+// RemoveDeviceFromWWIDSFile removes multipath device from /etc/multipath/wwids file.
+func (mp *Multipath) RemoveDeviceFromWWIDSFile(ctx context.Context, wwid string) error {
+	defer tracer.TraceFuncCall(ctx, "multipath.RemoveDeviceFromWWIDSFile")()
+	return mp.removeDeviceFromWWIDSFile(ctx, wwid)
+}
+
 // IsDaemonRunning check if multipath daemon running
 func (mp *Multipath) IsDaemonRunning(ctx context.Context) bool {
 	defer tracer.TraceFuncCall(ctx, "multipath.IsDaemonRunning")()
@@ -146,6 +152,12 @@ func (mp *Multipath) isDaemonRunning(ctx context.Context) bool {
 func (mp *Multipath) flushDevice(ctx context.Context, deviceMapName string) error {
 	logger.Info(ctx, "multipath - start flush dm: %s", deviceMapName)
 	_, err := mp.runCommand(ctx, multipathTool, []string{"-f", deviceMapName})
+	return err
+}
+
+func (mp *Multipath) removeDeviceFromWWIDSFile(ctx context.Context, wwid string) error {
+	logger.Info(ctx, "multipath - remove from wwids file wwid: %s", wwid)
+	_, err := mp.runCommand(ctx, multipathTool, []string{"-w", wwid})
 	return err
 }
 

--- a/rdm.go
+++ b/rdm.go
@@ -67,7 +67,7 @@ func (fc *FCConnector) cleanRDMConnection(ctx context.Context, force bool, info 
 		return errors.New(msg)
 	}
 	logger.Info(ctx, "devices found: %s", devices)
-	return fc.baseConnector.cleanDevices(ctx, force, devices)
+	return fc.baseConnector.cleanDevices(ctx, force, devices, wwn)
 }
 
 func (fc *FCConnector) validateRDMVolumeInfo(ctx context.Context, info RDMVolumeInfo) error {


### PR DESCRIPTION
# Description
Gobrick executes the following set of commands for removing a multipath device:

```bash
multipath -f /dev/dm-2
echo 1 > /sys/class/block/sdf/device/delete
multipathd del path /dev/sdf
```

These commands do not remove entries from the /etc/multipath/wwids file, resulting in stale entries being left behind. The growing count of entries could potentially impact the performance of multipath if the file becomes exceptionally large.

To address this issue, Gobrick should be enhanced to remove a device from the `wwids` file using below command:
```bash
multipath -w mpathX (or WWID)
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1447 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Executed UT 
![image](https://github.com/user-attachments/assets/9f9dfe2a-0d23-460f-ac00-730088627903)
- [x] Installed the fix with unity driver and validated that the wwids are getting removed from the /etc/multipath/wwids file
![image](https://github.com/user-attachments/assets/eaf30521-f1e2-452a-a45c-869650fa3347)
![image](https://github.com/user-attachments/assets/58e7dac8-e9df-40b3-a75a-2aca1d9d7878)
![image](https://github.com/user-attachments/assets/5b0eb730-c5e5-43b0-8f69-850588bb9028)
- [x] Installed the fix with powerstore driver and validated that the wwids are getting removed from the /etc/multipath/wwids file
![image](https://github.com/user-attachments/assets/ff2d7090-c84b-4fdb-9887-a72224c750be)
![image](https://github.com/user-attachments/assets/2eb803c0-4903-47af-b736-fa2ff36757a6)

