### PR TITLE
adding path suffix to multipath chroot command

### DIFF
--- a/pkg/multipath/multipath.go
+++ b/pkg/multipath/multipath.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/dell/gobrick/internal/logger"
@@ -200,7 +201,7 @@ func (mp *Multipath) runCommand(ctx context.Context, command string, args []stri
 	}
 
 	if mp.chroot != "" {
-		args = append([]string{mp.chroot, command}, args...)
+		args = append([]string{mp.chroot + os.Getenv("MP_CHROOT_SUFFIX"), command}, args...)
 		command = "chroot"
 	}
 	logger.


### PR DESCRIPTION
# Description
This PR adds the ability to add a path suffix to the chroot command issued when trying to invoke multipath commands through an environment variable. This was necessary on the environment I work in because our multipath daemon and associated binaries are located in /usr/local. When the chroot command would run it would try to chroot to /noderoot, but in my case it needed to chroot to /noderoot/usr/local. The additional env var allows this to happen wiout impacting current functionality. If there is another way you would like this implemented I'm open to suggestions.

The reason my multipath daemon is installed in /usr/local is because we are running a distribution called Talos (https://www.talos.dev/). This distribution does not come with multipath, and also has an immutable root filesystem, but they do have a system for adding extensions into /usr/local. So I have created a multipath extension for this distro that installs multipath into /usr/local.

# GitHub Issues
N/A

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
This has been tested by running local unit tests as well as running in my environment with the Dell Unity CSI Driver (https://github.com/dell/csi-unity). I validated that in our environment the multipath commands are now being executed correctly because of the updated chroot path.

If this PR is accepted there should also be an update made to the values file for the csi-unity helm chart that documents that this variable is available and the impact it can have.


